### PR TITLE
Fix "thematic" to "The Thematic" for consistency

### DIFF
--- a/src/en/docs/04.md
+++ b/src/en/docs/04.md
@@ -117,7 +117,7 @@ The example sentences above illustrate that the deletion of implied arguments re
 
 The **Transrelative** cases refer to nine cases used to identify nouns functioning as participants to a verb, what in Western grammatical terms would be referred to as “subjects” and “objects” and most likely marked as either nominative, accusative, or dative. It is these cases which more or less correspond to the semantic roles identified in Sec. 4.1 above. The nine transrelative cases are the **THEMATIC**, **INSTRUMENTAL**, **ABSOLUTIVE**, **AFFECTIVE**, **STIMULATIVE**, **EFFECTUATIVE**, **ERGATIVE**, **DATIVE**, and **INDUCIVE**. Following are explanations of the function and usage of each case. Examples of these cases in use are provided in [Sec. 4.2.10](04#Sec4_2_10) below.
 
-### 4.2.1 <abbr>THM</abbr> thematic Case {#Sec4_2_1}
+### 4.2.1 <abbr>THM</abbr> The Thematic Case {#Sec4_2_1}
 
 The **THEMATIC** case is marked by the `Vc` affix -**a** in Slot IX of a formative. It indicates the (usually inanimate) party which is a participant to the verbal predicate where that participant does not undergo any tangible change of state. Its semantic role is that of CONTENT, as described earlier in Sec. 4.1.2.
 


### PR DESCRIPTION
It might be worth double-checking other languages?