### PR TITLE
Translate 00.md, 01.md and cheat.md into Japanese

### DIFF
--- a/src/ja/docs/00.md
+++ b/src/ja/docs/00.md
@@ -3,4 +3,4 @@ title: はじめに
 order: 1
 ---
 
-This website presents the grammar of New Ithkuil, a design for a constructed human-usable language. The language uses a matrix of grammatical concepts intended to express deeper levels of human cognition more overtly, logically, and precisely than natural languages. The language is based upon a predecessor, [Ithkuil](http://ithkuil.net/00_intro.html), but has been significantly modified to incorporate various suggestions for improvements from fans of the predecessor language (see [Appendix C](15#C) for a list of these contributors) as well as new ideas from its author. New Ithkuil is far more systematic and regularized in its structure compared to its predecessor, making it potentially easier to study and learn.
+このウェブサイトでは、人間が実際に使える人工言語として設計された「新イスクイル（New Ithkuil）」の文法を紹介しています。この言語は、人間のより深いレベルの認知を、自然言語よりも明示的かつ論理的、そしてより正確に表現するできるように、体系化された文法概念を使用しています。この言語は前身であるイスクイルをベースとしていますが、前身言語のファンから寄せられた様々な改善提案（貢献者のリストについては[付録C](15#C)を参照）や、作者自身の新たなアイデアを取り入れ、大幅に修正が加えられています。新イスクイルはその前身と比べて構造がはるかに体系化・規則化されており、学習や習得がより容易になる可能性を秘めています。

--- a/src/ja/docs/01.md
+++ b/src/ja/docs/01.md
@@ -2,156 +2,170 @@
 title: 01 音韻論
 ---
 
-## 1.0 Phonology {#Sec1}
+## 1.0 音韻論 {#Sec1}
 
-The phonology of a language refers to its system of vocally articulated sounds and how those sounds are sequentially combined to build words.
+ある言語の音韻論とは、音声として発声される音の体系と、単語を形成するためにそれらの音がどのように連続して組み合わされるかについての仕組みのことです。
 
-## 1.1 Phonemic Inventory {#Sec1_1}
+## 1.1 音素体系 {#Sec1_1}
 
-The phonemes of a language are the meaningful vocally articulated sounds used to form words. Each such sound may have one or more variations (called allophones) depending on its phonetic environment (i.e., what other sounds are placed adjacent to it). This language has 31 consonant phonemes and 9 vowel phonemes, shown by place and manner of articulation in the chart below. Note that the primary writing system for the language is alien and not based on the Roman alphabet; it is explained in [Chapter 12](12). The characters used to represent the sounds below are a special romanized orthography used as a secondary or alternate means of displaying the written language to provide persons studying the language an easier way of seeing the structure of the words.
+音素とは、単語を形成するために用いられる、調音された意味のある音声のことです。それぞれの音素は、その音声的な環境（すなわち、どのような音が隣接して配置されるか）に応じて、1つ以上の変種（異音と呼ばれる）を持つ場合があります。この言語には31個の子音音素と9個の母音音素があり、下の表において調音部位および調音方法ごとに示されています。なお、この言語の主要な文字体系にはこの言語独自のものが用いられており、ラテンアルファベットに基づくものではないことに留意してください。これについては[第12章](12)で解説されています。下の表で音を表すために用いられている文字は特別なローマ字表記です。これは、この言語を学習する人々が単語の構造をより容易に把握できるように、本来の表記体系を補完、あるいは代替する手段として使用されています。
 
 ::: tabs
 
-@tab Consonants
+@tab 母音
 
 <div class="table-1">
 
-| PLACE | STOP | NASAL |
-|:------:|:------:|:------:|
-| LABIAL | p b | m |
-| APICO-DENTAL | t d | n |
-| VELAR | k g | ň |
-| GLOTTAL | ʼ | |
-
-| PLACE | FRICATIVE | AFFRICATE |
-|:------:|:------:|:------:|
-| LABIO-DENTAL | f v | |
-| INTER-DENTAL | ţ ḑ | |
-| APICO-ALVEOLAR | s z | c ẓ |
-| ALVEOLO-PALATAL | š ž | č j |
-| PALATAL | ç | |
-| VELAR | x | |
-| GLOTTAL | h | |
-| LATERAL | ļ | |
-
-| PLACE | FLAP~TRILL | APPROXIMANT |
-|:------:|:------:|:------:|
-| LABIO-VELAR | | w |
-| ALVEOLAR | r | |
-| PALATAL | | y |
-| UVULAR | | ř |
-| LATERAL | | l |
-
-</div>
-
-@tab Vowels
-
-<div class="table-2">
-
-| VOWEL | FRONT | CENTRAL | BACK |
-| :--: | :--: | :-: | :-: |
-| HIGH | i | ü | u |
-| MID | e ö | ë | o |
-| LOW | ä | | a |
+| 舌の位置→<br>↓広さ | 前 | 中 | 後 |
+|:----------------:|:--:|:--:|:-:|
+|        狭        |  i  | ü | u |
+|        半        | e ö | ë | o |
+|        広        |  ä  |   | a |
 
 </div>
 
 ::: center
-o u ö ü are rounded vowels.
+
+o u ö ü は円唇母音です。
+
+@tab 子音
+
+<div class="table-2">
+
+### 閉鎖音・鼻音
+
+|  部位＼方法 | 閉鎖音 | 鼻音 |
+|:---------:|:-----:|:---:|
+|  **両唇**  |  p b  |  m  |
+|   **歯**   |  t d  |  n  |
+| **軟口蓋** |  k g  |  ň  |
+|  **声門**  |   ʼ   |     |
+
+### 摩擦音・破擦音
+
+|   部位＼方法   | 摩擦音 | 破擦音 |
+|:-------------:|:-----:|:-----:|
+|   **唇歯**    |  f v  |       |
+|    **歯**     |  ţ ḑ  |       |
+|   **歯茎**    |  s z  |  c ẓ  |
+| **硬口蓋歯茎** |  š ž  |  č j  |
+|   **硬口蓋**  |   ç   |       |
+|   **軟口蓋**  |   x   |       |
+|   **口蓋垂**  |   ř   |       |
+|   **声門**    |   h   |       |
+|   **側面**    |   ļ   |       |
+
+### はじき/ふるえ音・接近音
+
+|   部位＼方法   | はじき・ふるえ音 | 接近音 |
+|:------------:|:-------------:|:-----:|
+| **両唇軟口蓋** |              |   w   |
+|   **歯茎**    |       r      |       |
+|  **硬口蓋**   |              |   y   |
+|   **側面**    |              |   l   |
+
+</div>
+
 :::
 
-## 1.2 Pronunciation Notes and Allophonic Distinctions {#Sec1_2}
+## 1.2 発音上の注意点と異音の区別について {#Sec1_2}
 
-### 1.2.1 Vowels {#Sec1_2_1}
+### 1.2.1 母音 {#Sec1_2_1}
 
-The sounds of the above-listed vowels are given below within brackets using the International Phonetic Alphabet.
+以下では国際音声記号を用いて、上の表にある母音の発音を括弧内に示しています。
 
-* **a** is pronounced [a] as in Spanish <q><strong>a</strong>lt<strong>a</strong></q><ins>, or as [ɑ] in English <q>f<strong>a</strong>ther</q></ins>.
-* **ä** is pronounced [æ] as in American English <q>c<strong>a</strong>t</q>.
-* **e** is pronounced [ɛ] as in English <q>l<strong>e</strong>t</q>, or as [e] in Spanish <q><strong>e</strong>st<strong>e</strong></q>, but only as [e] at the beginning of a bivocalic conjunct such as -**ea**-, -**eo**-, -**eö**-, etc.
-* **ë** is pronounced [ʌ] like the *u* in English <q>c<strong>u</strong>t</q>, or the “schwa” sound [ə] like the *a* in English <q>sof<strong>a</strong></q><ins>, or as [ɤ] in Mandarin</ins>.
-* **i** is pronounced [i] as in Spanish or Italian, or [ɪ] as in English <q>p<strong>i</strong>t</q>, but only as [i] at the beginning of a bivocalic conjunct (e.g., -**ia**-, -**iö**-, etc.) and only as [ɪ] when preceded or followed by **y**.
-* **o** is pronounced [ɔ] like the first *o* in Italian <q><strong>o</strong>tto</q>, or [o] as in Spanish, but only as [o] at the beginning of a bivocalic conjunct such as -**oa**-, -**oe**-, etc.
-* **ö** is pronounced [œ] as in French <q>n<strong>eu</strong>f</q> or [ø] as in French <q>f<strong>eu</strong></q>, but only [ø] at the beginning of a bivocalic conjunct such as -**öa**-, -**öe**-, etc.
-* **u** is pronounced [ʊ] as in English <q>b<strong>oo</strong>k</q>, or [u] as in Spanish, but only [u] at the beginning of a bivocalic conjunct and only as [ʊ] when preceded or followed by **w**.
-* **ü** is pronounced [ʉ] as in Swedish <q>h<strong>u</strong>s</q> or the Scottish pronunciation of <q>b<strong>oo</strong>k</q>, or [y] as in French <q>l<strong>u</strong>ne</q>, but only as [ʉ] when preceded by **y** or **w**.
+* **a** はスペイン語の <strong>a</strong>lt<strong>a</strong> のように [a] と発音されるか、または英語の f<strong>a</strong>ther のように [ɑ] と発音されます。
+* **ä** はアメリカ英語の c<strong>a</strong>t のように [æ] と発音されます。
+* **e** は英語の l<strong>e</strong>t の [ɛ] またはスペイン語の <strong>e</strong>st<strong>e</strong> の [e] として発音されますが、-**ea**-, -**eo**-, -**eö**- などの二母音接続の先頭では常に [e] と発音されます。
+* **ë** は英語の c<strong>u</strong>t の [ʌ] や sof<strong>a</strong> の **a** のような曖昧母音 [ə] として発音されたり、標準中国語の [ɤ] のように発音されたりします。
+* **i** はスペイン語やイタリア語のように [i] と発音されるか、英語の p<strong>i</strong>t のように [ɪ] と発音されますが、二母音接続（例: -**ia**-, -**iö**- など）の先頭では常に [i] となり、前か後ろに **y** がある場合は常に [ɪ] と発音されます。
+* **o** はイタリア語の <strong>o</strong>tto の最初の **o** のように [ɔ] と発音されるか、スペイン語のように [o] と発音されますが、-**oa**-, -**oe**- などの二母音接続の先頭では常に [o] と発音されます。
+* **ö** はフランス語の n<strong>eu</strong>f の [œ] や f<strong>eu</strong> の [ø] として発音されますが、-**öa**-、-**öe**- などの二母音接続の先頭では常に [ø] と発音されます。
+* **u** は、英語の b<strong>oo</strong>k のように [ʊ] と発音されるか、スペイン語のように [u] と発音されますが、二母音接続の先頭では常に [u] となり、前後に **w** がある場合は常に [ʊ] と発音されます。
+* **ü** はスウェーデン語の h<strong>u</strong>s やスコットランド英語の b<strong>oo</strong>k のように [ʉ] と発音されるか、フランス語の l<strong>u</strong>ne のように [y] と発音されますが、前後に **y** や **w** がある場合は常に [ʉ] と発音されます。
 
-The permissible diphthongs (all are “falling”) are: **ai**, **ei**, **ëi**, **oi**, **ui**, **au**, **eu**, **ëu**, **ou**, and **iu**. The two vowels of these diphthongs may be pronounced as separate syllables in the following circumstances:
+許容される二重母音（すべて<ruby>下降<rt>・・</rt></ruby>二重母音）は次の通りです: **ai**, **ei**, **ëi**, **oi**, **ui**, **au**, **eu**, **ëu**, **ou**, **iu**
+これら二重母音を構成する2つの母音は、次の状況では別々の音節として発音されることがあります。
 
-1. for ease-of-pronunciation when followed by -**l**, -**r** or -**ř** occurring in the same syllable;
-2. in song or poetry.
+1. 同じ音節内で -**l**, -**r**, -**ř** が続き、発音を容易にしたいとき
+2. 歌や詩の中
 
-Care should be taken not to accidentally introduce a glottal-stop between the two vowels when pronouncing a diphthong disyllabically.
+二重母音を2音節に分けて発音する際、誤って2つの母音の間に声門閉鎖音を入れないよう注意する必要があります。
 
-### 1.2.2 Consonants {#Sec1_2_2}
+### 1.2.2 子音 {#Sec1_2_2}
 
-The sounds of the consonants in the table above are given below within brackets using the International Phonetic Alphabet.
+以下では国際音声記号を用いて、上の表にある子音の発音を括弧内に示しています。
 
-* **p** and **k** are unaspirated [p] and [k] as in French, Spanish, or Italian.
-* **t** is unaspirated and dental (not alveolar) [t̪] as in French, Spanish, or Italian.
-* **d** is dental (not alveolar) [d̪] as in French or Italian.
-* **g** is always the voiced velar stop [g] as in English <q><strong>g</strong>o</q>.
-* **h** is never silent and is pronounced [h] in all positions where it appears, even in word-final position. Syllable-initial or word-final -**ph**-, -**th**-, -**kh**-, -**ch**-, -**čh**- are pronounced as aspirated stops/affricates [pʰ, tʰ, kʰ, tsʰ, tʃʰ]but when between two vowels, they are disyllabic and pronounced as in English <q>ha<strong>ph</strong>azard</q>, <q>a<strong>t-h</strong>and</q>, <q>ba<strong>ckh</strong>anded</q>, <q>i<strong>t’s h</strong>ere</q> and <q>chur<strong>ch h</strong>all</q>; the combinations -**hl**-, -**hr**-, -**hm**- and -**hn**- may be pronounced as separate consonants or as the following single voiceless consonants: **hl** = [ɬ], **hr** = [ɾ̥], **hm** = [m̥], **hn** = [n̥]. Combinations of a voiced consonant plus following **h** are always dissyllabic, e.g., -**bh**-, -**dh**-, -**gh**-, -**rh**-, -**mh**-, -**nh**-, etc.
-* **ʼ** is the voiceless glottal stop [Ɂ] as heard between the two vowels of English <q>oh-oh!</q>, or between the first two e-sounds of German <q>beendete</q><ins>, or the one possible realization of the zero phoneme in Mandarin 親愛 (<q>qīn<strong>ʼ</strong>ài</q> [t͡ɕʰji̞n̚˥.ʔa̠ɪ̯˥˩], different from <q>qīnài</q> [t͡ɕʰi˥.na̠ɪ̯˥˩] or <q>qīnnài</q> [t͡ɕʰji̞n̚˥.na̠ɪ̯˥˩]); For the voiceless glottal stop in the syllable initial, cf. the distinctions in Hawaiian or some Ryukyuan languages; For the voiceless glottal stop in the syllable coda, cf. the distinctions in Wu or Min Chinese languages, as well as Japanese あっ (<q>a<strong>Q</strong></q>, [äʔ])</ins>.
-* **ţ** and **ḑ** are the voiceless and voiced interdental fricatives [θ] and [ð] as in English <q><strong>th</strong>in</q> and <q><strong>th</strong>is</q>, or Castilian Spanish <q>ca<strong>z</strong>a</q> and <q>ca<strong>d</strong>a</q>
-* **š** and **ž** are the voiceless and voiced alveolo-palatal fricatives [ʃ] and [ʒ], both unrounded. As in English <q>me<strong>sh</strong></q> and <q>mea<strong>s</strong>ure</q> but without rounded lips.
-* **ç** is the voiceless non-grooved palatal slit-fricative [ç], as heard in the initial sound of English <q><strong>h</strong>uman</q> or <q><strong>h</strong>ue</q>, or in the German word <q>ri<strong>ch</strong>tig</q>, <ins>or in Japanese ひ (*hi*) and the palatalization <q><strong>hy</strong>-</q></ins>.
-* **x** is either a velar or uvular voiceless fricative [x ~ χ], as in either Latin American or Castilian Spanish <q><strong>j</strong>ota</q>, Russian <q><strong>х</strong>орошо</q>, German <q>ba<strong>ch</strong></q>, or Mandarin **h-**.
-* **l** is the non-velarized voiced apico-dental lateral approximant [l̪]as in French, Spanish, or Italian; never the velarized “dark” l-sound of American English.
-* **ļ** is the voiceless lateral fricative [ɬ] as found in Welsh <q><strong>ll</strong>an</q>.
-* **c** and **ẓ** are the voiced and voiceless apico-alveolar affricates [ts] and [dz] as in English <q>bi<strong>ts</strong></q> and <q>bi<strong>ds</strong></q> or Italian <q>pi<strong>zz</strong>a</q> and <q>a<strong>zz</strong>urro</q>.
-* **č** and **j** are the voiced and voiceless apico-alveolar affricates [tʃ] and [dʒ] as in English <q>bu<strong>tch</strong></q> and <q>bu<strong>dg</strong>e</q>.
-* **n** is dental, not alveolar; **n** assimilates to velar [ŋ] before **k**, **g**, and **x** (but not before **ř**); therefore, phonemic **ň** is not permitted before **k**, **g**, or **x** <ins>in New Ithkuil native words</ins>.
-* **ň** is velar [ŋ] as in English <q>bri<strong>ng</strong></q>.
-* **r** is a single tap/flap [ɾ], which becomes a trill [r] when geminated, as in Spanish or Italian <q>ca<strong>r</strong>o</q> and <q>ca<strong>rr</strong>o</q>; when followed by a consonant in the same word, it may be pronounced as an apico-alveolar approximant [ɹ], similar to (but further forward in the mouth than) the postalveolar [ɹ̱] of standard English. <ins>An example of an apico-alveolar approximant is the non-retroflex <q><strong>r</strong></q> sound in Mandarin.</ins>
-* **ř** is the voiced dorso-uvular approximant [ʁ] as in French <q><strong>r</strong>i<strong>r</strong>e</q> or German <q><strong>R</strong>uhr</q>; when geminated it is either [ʁː] or can be strengthened to a uvular trill [ʀ]; care should be taken to ensure the pronunciations of -**př**- and -**tř**- are differentiated from -**px**- and -**tx**-.
-* **y** is the voiced palatal approximant [j] as in English <q><strong>y</strong>es</q> or German <q><strong>j</strong>a</q>.
+* **p** と **k** はフランス語、スペイン語、イタリア語のように無気音の [p] と [k] です。
+* **t** は無気音であり、フランス語、スペイン語、イタリア語のように（歯茎音ではなく）歯音の [ t̪ ] です。
+* **d** はフランス語やイタリア語のように（歯茎音ではなく）歯音の [ d̪ ] です。
+* **g** は英語の <strong>g</strong>o のように、常に有声軟口蓋閉鎖音の [g] です。
+* **h** は決して黙字にはならず、語末を含めたすべての位置で [h] と発音されます。音節頭や語末の -**ph**-, -**th**-, -**kh**-, -**ch**-, -**čh**- は有気閉鎖音/有気破擦音の [pʰ, tʰ, kʰ, tsʰ, tʃʰ] として発音されますが、2つの母音の間にある場合は2音節となり、英語の ha<strong>ph</strong>azard, a<strong>t-h</strong>and, ba<strong>ckh</strong>anded, i<strong>t’s h</strong>ere,  chur<strong>ch h</strong>all のように発音されます。-**hl**-, -**hr**-, -**hm**-, -**hn**- の組み合わせは別々の子音として発音されるか、あるいは次のような単一の無声子音として発音されることがあります: **hl** = [ɬ], **hr** = [ ɾ̥ ], **hm** = [ m̥ ], **hn** = [ n̥ ] 。有声子音の後に **h** が続く組み合わせは常に2音節となります（例：-**bh**-, -**dh**-, -**gh**-, -**rh**-, -**mh**-, -**nh**- など）。
+* **ʼ** は無声声門閉鎖音の [ʔ] であり、英語の oh-oh! の2つの母音の間や、ドイツ語の beendete の最初の2つのeの音の間で聞かれる音です。あるいは、北京語の 親愛 （qīn<strong>ʼ</strong>ài [t͡ɕʰji̞n̚˥.ʔa̠ɪ̯˥˩] 。qīnài [t͡ɕʰi˥.na̠ɪ̯˥˩] や qīnnài [t͡ɕʰji̞n̚˥.na̠ɪ̯˥˩] とは異なる）におけるゼロ音素の実現形の一つでもあります。音節頭での発音についてはハワイ語や一部の琉球諸語における対立を、音節末での発音については呉語や<ruby>閩語<rt>びんご</rt></ruby>などの中国語諸語における対立や日本語の あっ（a<strong>Q</strong> [äʔ]）を参照してください。
+* **ţ** と **ḑ** は無声および有声の歯摩擦音 [θ] と [ð] であり、英語の <strong>th</strong>in や <strong>th</strong>is、またはスペイン本土のスペイン語の ca<strong>z</strong>a や ca<strong>d</strong>a のような音です。
+* **š** と **ž** は無声および有声の硬口蓋歯茎摩擦音 [ʃ] と [ʒ] であり、どちらも非円唇です。英語の me<strong>sh</strong> や mea<strong>s</strong>ure のような音ですが、唇は丸めません。
+* **ç** は無声硬口蓋扁平摩擦音 [ç] であり、英語の <strong>h</strong>uman や <strong>h</strong>ue の語頭音、またはドイツ語の ri<strong>ch</strong>tig、あるいは日本語の ひ や”は行”が口蓋化した”ひゃ行”の音として聞かれる音です。
+* **x** は無声の軟口蓋摩擦音 [x] または口蓋垂摩擦音 [χ] のいずれかであり、ラテンアメリカやスペイン本土のスペイン語の <strong>j</strong>ota、ロシア語の <strong>х</strong>орошо、ドイツ語の ba<strong>ch</strong>、または北京語の **h-** のような音です。
+* **l** はフランス語・スペイン語・イタリア語で用いられる、軟口蓋化していない有声舌尖歯側面接近音 [ l̪ ] であり、アメリカ英語の軟口蓋化されたいわゆる暗いL（dark L）として発音されることはありません。
+* **ļ** は無声側面摩擦音 [ɬ] であり、ウェールズ語の <strong>ll</strong>an に見られる音です。
+* **c** と **ẓ** は無声および有声の舌尖歯茎破擦音 [ts] と [dz] であり、英語の bi<strong>ts</strong> や bi<strong>ds</strong>、またはイタリア語の pi<strong>zz</strong>a や a<strong>zz</strong>urro のような音です。
+* **č** と **j** は無声および有声の硬口蓋歯茎破擦音 [tʃ] と [dʒ] であり、英語の bu<strong>tch</strong> や bu<strong>dg</strong>eのような音です。
+* **n** は歯茎音ではなく歯音です。**n** は **k**, **g**, **x** の前では軟口蓋音の **ň** [ŋ] に同化します（ただし **ř** の前では同化しません）。したがって、新イスクイルの固有語においては、**k**, **g**, **x** の前に音素としての **ň** を置くことはできません。
+* **ň** は軟口蓋音の [ŋ] であり、英語の bri<strong>ng</strong> のような音です。
+* **r** は単一のたたき/はじき音 [ɾ] であり、重音化（[子音の重音化](#Sec1_4)を参照のこと）されるとスペイン語やイタリア語の ca<strong>r</strong>o と ca<strong>rr</strong>o の違いのように、ふるえ音 [r] になります。同じ単語内で別の子音が続く場合は、標準英語の後部歯茎音 [ ɹ̱ ] に似た（ただしそれよりも前方で調音される）舌尖歯茎接近音 [ɹ] として発音されることがあります。舌尖歯茎接近音の例としては、北京語における非そり舌音の <strong>r</strong> の音があります。
+* **ř** は有声舌背口蓋垂摩擦音 [ʁ] であり、フランス語の <strong>r</strong>i<strong>r</strong>e やドイツ語の <strong>R</strong>uhr のような音です。重音化された場合は [ʁː] になるか、口蓋垂ふるえ音 [ʀ] に強められることがあります。-**př**- および -**tř**- の発音は、-**px**- および -**tx**- と明確に区別されるよう注意する必要があります。
+* **y** は有声硬口蓋接近音 [ j ] であり、英語の <strong>y</strong>es やドイツ語の <strong>j</strong>a のような音です。
 
-The remaining consonants **b**, **f**, **m**, **s**, **v**, **w**, and **z** are pronounced as in English and as in the International Phonetic Alphabet.
+残りの子音 **b**, **f**, **m**, **s**, **v**, **w**, **z** は英語や国際音声記号での発音の通りです。
 
-#### Epenthetic Vowel Following a Glottal Stop
+#### 声門閉鎖音に続く挿入母音
 
-In words where a glottal stop (spelled ’ ) is followed by a consonant (e.g., as in the words *ka’tal* or *morui’ss*), the glottal stop is usually followed by a very briefly pronounced vowel sound before the following consonant is pronounced. This vowel may be pronounced in either of two ways, whichever is easier for the speaker. The first is as the high central unrounded vowel of Russian <q>б<strong>ы</strong>ть</q>, IPA [ɨ]. The second way is to pronounce it as the high back unrounded vowel found in Turkish (spelled with an undotted i), or Japanese (as the short vowel u), IPA [ɯ]. Both of these vowels are extremely short in duration and may be de-voiced if the following consonant is voiceless.
+声門閉鎖音（ ’ と表記される）の後に子音が続く語（例: *ka’tal*, *morui’ss*）では、後続の子音を発音する前に、声門閉鎖音に続いてごく短い母音が伴います。この母音は、以下の2つのうち話者にとって発音しやすい方法で発音されます。
 
-## 1.3 Orthographic Conventions {#Sec1_3}
+1. ロシア語の б<strong>ы</strong>ть に見られる**非円唇中舌狭母音**、IPA（国際音声記号）における **[ɨ]**
+2. トルコ語（ ı ）や日本語（短母音の う ）に見られる**非円唇後舌狭母音**、IPAにおける **[ɯ]** 
 
-The following alternatives are available for writing the language in romanized script: The character **ţ** may be written as **ṭ** or **ŧ**; the character **ḑ** may be written as **ḍ** or **đ**; the character **ň** may be written as **ņ** or **ṇ**; the character **ř** may be written as **ŗ** or **ṛ**; the character **ļ** may be written as **ł** or **ḷ**; the character **ẓ** may be written as **ż**.
+これらの母音はどちらも持続時間が極めて短く、後続の子音が無声音である場合には無声化することがあります。
 
-### 1.3.1 Indicating Syllabic Stress {#Sec1_3_1}
+## 1.3 正書法の規則 {#Sec1_3}
 
-Penultimate stress (i.e., stress on the syllable-before-last) is unmarked; non-penultimate stress is marked by a diacritic on the vowel carrying the stress, as follows:
+この言語のローマ字表記においては、次のような代替表記を用いることができます: 文字 **ţ** は **ṭ** または **ŧ** と表記してもよく、文字 **ḑ** は **ḍ** または **đ** と、文字 **ň** は **ņ** または **ṇ** と、文字 **ř** は **ŗ** または **ṛ** と、文字 **ļ** は **ł** または **ḷ** と、文字 **ẓ** は **ż** と表記することもできます。
 
-* a vowel with no diacritic takes the acute accent (e.g., **á**, **ó**, etc.);
-* a vowel with a dieresis changes it to a circumflex accent (e.g., **ö** → **ô**).
+### 1.3.1 音節強勢の標示 {#Sec1_3_1}
 
-The grave accent is used over the vowel **i** when it is unstressed as the initial member of a vocalic conjunct following a consonant (e.g., -**Cìa**-, -**Cìo**-, etc.) — this is to remind the speaker/reader that this -**ì**- is to be pronounced as a long /i:/ in order to distinguish such syllables from syllables of the form **Cy+V** (e.g., *karesya* vs. *karésìa*, *velkyo* vs. *vélkìo*). A grave accent may similarly be used over the vowel **u** to remind the speaker/reader not to collapse the /u/-sound into /w/ in words like **ehùá**.
+次末音節（すなわち、語末から2番目の音節）の強勢は無標です。次末音節以外の強勢は、以下のように強勢を帯びる母音上に補助記号を付すことで標示されます。
 
-### 1.3.2 Written juncture affixes/adjuncts {#Sec1_3_2}
+* 補助記号のない母音には揚音符を付ける（例: **á**, **ó** など）
+* 補助記号のある母音では、それを揚抑符に変える（例: **ö** → **ô**）
 
-In regard to parsing adjuncts (see [Sec. 2.7, No. 5](02#Sec2_7)) and the **ç(ë)**- sentence-juncture affix (see [Sec. 11.8](11#Sec11_8)), these are normally never written in either the romanization scheme or the native New Ithkuil script, given that their occurrence is entirely dependent on the specific way any given individual utters a sentence or group of sentences on any particular occasion. The exception would be in the narrow context of a scripted utterance (e.g., a script for a play or screenplay), in poetry, in a rhetorical recital, or in singing instructions, where explicit direction of the exact vocalization is crucial.
+子音の直後に続く母音接続の先頭にある **i** が強勢を帯びない場合、抑音符を付けてこれを標示します（例: -**Cìa**-, -**Cìo**- など）。これは話者や読者に対して、これらの音節を **Cy+V** の形の音節（例: *karesya* vs. *karésìa*、*velkyo* vs. *vélkìo*）と区別するために -**ì**- が長い /i:/ として発音されることを伝えるためです。同様に、抑音符は **u** にも付されることがあり、この場合は **ehùá** のような単語で /u/ の音が /w/ に同化しないことを話者や読者に思い起こさせるために使用されます。 
 
-## 1.4 Gemination of Consonants {#Sec1_4}
+### 1.3.2 書面音渡接辞／付属詞 {#Sec1_3_2}
 
-Consonantal gemination refers to the audible “doubling” in length of a particular consonant sound. While gemination does not occur in English on true phonological grounds, it does occur on morpho-phonological grounds, as seen in the difference in pronunciation of the phrase <q>a <strong>n</strong>atural</q> versus <q>u<strong>nn</strong>atural</q>. There are many languages, however, where phonologically-based gemination is an intrinsic component of the phonology (e.g., Italian, Japanese, Finnish).
+**ç(ë)**- 文音渡接辞（[第11.8節](11#Sec11_8)を参照）および分析付属詞（[第2.7節 No. 5](02#Sec2_7)を参照）については、ローマ字表記でも新イスクイル独自の文字表記でも、通常は文字として書き記されることは決してありません。なぜなら、これらが出現するかどうかは、特定の状況下で個々の話者が文や複数の文のまとまりを発話する際の、その時々の発音の仕方に完全に依存しているからです。ただし、台本に基づいた発話（演劇や映画の脚本など）、詩、修辞的な朗読、あるいは歌唱のための指示といった限られた文脈においては例外となります。こうした場面では、正確な発声方法を明示的に指定することが不可欠だからです。
 
-In New Ithkuil, most consonants can be geminated. All consonants except for **w**, **y**, and the glottal stop **’** are capable of gemination between two vowels. In addition, all consonants except for **w**, **y**, and the stop consonants (-**’**, **p**, **b**, **t**, **d**, **k**, **g**) can be geminated in both word-initial and word-final position.
+## 1.4 子音の重音化 {#Sec1_4}
 
-### Pronunciation of Geminated Consonants
+子音の重音化とは、ある特定の子音の長さが聴覚的に”2倍”になることを指します。英語では純粋な音韻論的根拠に基づいた重音化は起こりませんが、a <strong>n</strong>atural と u<strong>nn</strong>atural の発音の違いに見られるように、形態音韻論に基づく重音化は発生します。しかしながら、音韻論による重音化が、その言語の音韻体系における本質的な構成要素となっている言語も数多く存在します（例：イタリア語、日本語、フィンランド語）。
 
-Consonants which are continuants (i.e., able to be sounded for an indefinite duration), specifically **ç**, **ḑ**, **f**, **h**, **l**, **ļ**, **m**, **n**, **ň**, **ř**, **s**, **š**, **ţ**, **v**, **x**, **z**, and **ž**, are simply pronounced for twice as long in duration when geminated. Geminated **r** is pronounced as a rapid apico-alveolar trill like <q>rr</q> in Spanish or Italian.
+新イスクイルではほとんどの子音を重音化することができます。**w**, **y** および声門閉鎖音 **’** を除くすべての子音は、2つの母音の間で重音化することが可能です。さらに、**w**, **y** および閉鎖音 (-**’**, **p**, **b**, **t**, **d**, **k**, **g**) を除くすべての子音は、語頭および語末の両方の位置で重音化することができます。
 
-The stop consonants **b**, **d**, **g**, **k**, **p**, and **t**, when geminated, are momentarily held, then released, much like the two *d*-sounds in the English phrase <q>ba<strong>d d</strong>og</q> when spoken rapidly.
+### 重音化された子音の発音
 
-The pronunciation of affricates (**c**, **č**, **j**, and **ż**) when geminated depends on whether or not they are intervocalic (between two vowels) versus word-initial or word-final position. If intervocalic, they are pronounced by momentarily holding the initial stop (plosive) component of the affricate before releasing it into the fricative or sibilant portion, e.g., intervocalic **čč** is pronounced as **ttš**. When in word-initial or word-final position, geminated pronunciation is achieved by simply lengthening the sibilant continuant portion of the affricate (i.e., the second sound of each affricate). Thus, **čč** in word-initial or word-final position is pronounced as **tšš**.
+継続音（無期限に音を伸ばすことができる子音）、具体的には **ç**, **ḑ**, **f**, **h**, **l**, **ļ**, **m**, **n**, **ň**, **ř**, **s**, **š**, **ţ**, **v**, **x**, **z**, **ž** については、重音化される場合、単純にその発音時間を2倍にします。重音化された **r** は、スペイン語やイタリア語の rr のような、速い舌尖歯茎ふるえ音として発音されます。
 
-### Romanized Orthography of Geminates
+閉鎖音である **b**, **d**, **g**, **k**, **p**, **t** を重音化する場合は、一瞬閉鎖を保持してから解放します。これは、英語の ba<strong>d d</strong>og を早口で発音したときの2つの *d* の音に非常によく似ています。
 
-Consonants written as single characters are simply written double when geminated, e.g., **bb**, **čč**, **dd**, **nn**, **šš**.
+破擦音 **c**, **č**, **ż**, **j** が重音化された場合の発音は、それが母音間にあるか、それとも語頭または語末の位置にあるかによって異なります。母音間にある場合は、破擦音の最初の閉鎖（破裂）成分を一瞬保持してから、摩擦音または歯擦音の成分へと移行することによって発音されます。例えば、母音間の **čč** は **ttš** のように発音されます。語頭または語末にある場合、重子音の発音は破擦音の摩擦音成分（各破擦音の2番目の音）を単に長く伸ばすことによって実現されます。したがって、語頭または語末における **čč** は **tšš** のように発音されます。
 
-## 1.5 Phonotactics {#Sec1_5}
+### 重子音のローマ字表記
 
-Phonotactics refer to the arbitrary rules as to what combinations of consonants and vowels are permissible in a syllable or word of a particular language. This concept is called **phonotaxis** and such rules are known as phonotactical rules. These rules, peculiar to each language, explain, for example, why *sprelch* could be a hypothetical word in English, while *znatk* could not be, even though *znatk* is as easily pronounced by a linguist as *sprelch*. Rules governing syllable structure, diphthong formation, and overall phonetic euphony are all part of phonotactics. The phonotactical rules for this language are numerous and complex, and are provided in a separate [Phonotactics](pt) document.
+単一の文字として表記される子音は、重音化される際、単に文字を2つ重ねて表記されます（例: **bb**, **čč**, **dd**, **nn**, **šš**）。
 
-## 1.6 Tone and Pitch {#Sec1_6}
+## 1.5 音素配列論 {#Sec1_5}
 
-Numerous languages in the world use the pitch and/or tone of one’s voice as a productive part of the phonology to distinguish meaning in words. Examples of such languages are Vietnamese, the various Chinese and other Southeast Asian languages, most of the sub-Saharan African languages, and some Native American languages such as Navajo. While New Ithkuil is not a tone language per se, it does employ a “pitch accent” system as the means by which word boundaries may be parsed by a listener. This is explained in [Sec. 2.7](02#Sec2_7).
+音素配列論とは、特定の言語の音節や単語において、どのような子音と母音の組み合わせが許容されるかについての恣意的な規則のことを指します。この概念は **音素配列** と呼ばれ、そのような規則は音素配列規則として知られています。それぞれの言語に固有のこれらの規則は、例えば言語学者にとっては *znatk* と *sprelch* は同じくらい発音が容易にもかかわらず、なぜ英語において *sprelch* は架空の単語として成立し得るのに、*znatk* はそうではないのかを説明してくれます。音素配列論には、音節構造、二重母音の形成、全体的な耳あたりの良さといった要素を規定する規則が全て含まれます。この言語における音素配列規則は非常に数が多く複雑であるため、別の[音素配列論に関するドキュメント](pt)にまとめて記載しています。
+
+## 1.6 音高と声調 {#Sec1_6}
+
+世界には、音高や声調を音韻論的に生産性のある要素として、単語の意味を区別するのに利用する言語が数多く存在します。そのような言語の例としては、ベトナム語、中国語をはじめとする様々な東南アジアの言語、サハラ以南のアフリカ諸言語の大部分、そしてナバホ語のような一部のアメリカ先住民の言語が挙げられます。新イスクイルは厳密な意味での声調言語ではありませんが、聞き手が単語の境界を解析するための手段として高低アクセントのシステムを採用しています。これについては[第2.7節](02#Sec2_7)で解説しています。

--- a/src/ja/docs/cheat.md
+++ b/src/ja/docs/cheat.md
@@ -2,6 +2,4 @@
 title: 早見表
 ---
 
-To be processed, please refer to [zsakowitz’ New Ithkuil Single Page Cheat Sheet](https://docs.google.com/presentation/d/1A1VWCSgwTOUJOJ7SHyglcUznFlkwI3zdOBy57aeGJ3A/edit?usp=sharing) instead.
-
-This enables the inclusion of a list aimed at referencing the most recent Cheat sheets created by others.
+現在製作中です。代わりに [zsakowitz’ New Ithkuil Single Page Cheat Sheet](https://docs.google.com/presentation/d/1A1VWCSgwTOUJOJ7SHyglcUznFlkwI3zdOBy57aeGJ3A/edit?usp=sharing) を参照してください.


### PR DESCRIPTION
## What

Translated the following files in src/ja/docs into Japanese:

- 00.md
- 01.md
- cheat.md

## Remark

Below is a summary in Japanese of the changes from the original text.
以下では翻訳する際に加えた、翻訳を超えるような変更点についてまとめています。

### 01.mdに関する変更

- 本文の説明の順序と合わせるため、母音の表と子音の表を入れ替え
- 母音の表について
  - 行と列の説明として左上のマスに「舌の位置」と「広さ」という文言を追加
  - `HIGH / MID / LOW` を直訳ではなく日本語の音声学の文脈で慣習的と思われる `狭 / 半 / 広` に変更
- 子音の表について
  - 表ごとに見出しを追加
  - 表の左上に説明として「部位＼位置」の文言を追加
  - ř を摩擦音の行に移動: 1.2.2節においても摩擦音として説明
  - 慣習的な用語に合わせて `APICO-`（舌尖）を省略: 1.2.2節の説明では舌尖を付与している
  - `ALVEOLO-PALATAL` を歯茎硬口蓋ではなく硬口蓋歯茎に翻訳: 1.2.2節においても同様
- 1.2.2節の c, ẓ, č, j の説明において、原文では `the voiced and voiceless... [ts] and [dz]` `[tʃ] and [dʒ]` と説明と記号の順が食い違っているが、和訳では記号の順に合わせて「無声および有声」に修正
- 中国語版に倣ってinsタグとqタグを削除
- `circumflex` を「抑揚符」と翻訳
- `Epenthetic Vowel Following a Glottal Stop` の節で、' の後に挿入される母音の説明を箇条書きに変更
- 1.3.2節の `Parsing Adjunct` を「分析付属詞」と翻訳
- 1.6節の見出し `Tone and Pitch` を本文中の記載の順番に合わせて「音高と声調」に

### cheat.mdに関する変更

中国語版を参考に `This enables the inclusion of a list aimed at referencing the most recent Cheat sheets created by others.` の翻訳を省略